### PR TITLE
Upgrades react-tether to work with react16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-power-select",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7848,12 +7848,12 @@
       }
     },
     "react-tether": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/react-tether/-/react-tether-0.5.7.tgz",
-      "integrity": "sha1-QY6mEEG2W5WCcUeEibcaNXLwFCI=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/react-tether/-/react-tether-0.6.1.tgz",
+      "integrity": "sha512-/1o2d77RyL78S1IjS1+yGMTKSldYMBVtu4H20zNIC9eAGsgA/KMxdLRcE3k32wj4TWCsVMPDnxeTokHuVWNLag==",
       "requires": {
         "prop-types": "15.5.10",
-        "tether": "1.4.0"
+        "tether": "1.4.3"
       }
     },
     "read-pkg": {
@@ -8874,9 +8874,9 @@
       }
     },
     "tether": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.0.tgz",
-      "integrity": "sha1-D5+hcfdb9YSF2BSelHmdeudNHBo="
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.3.tgz",
+      "integrity": "sha512-YCfE/Ym9MpZpzUmzbek7MiLEyTofxx2YS0rJfSOUXX0aZtfQgxcgw7/Re2oGJUsREWZtEF0DzBKCjqH+DzgL6A=="
     },
     "text-encoding": {
       "version": "0.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-power-select",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "description": "A highly composable & reusable select component in react",
   "main": "lib/index.js",
   "scripts": {
@@ -103,6 +103,6 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.10",
-    "react-tether": "^0.5.7"
+    "react-tether": "^0.6.1"
   }
 }


### PR DESCRIPTION
We have upgraded to react 16 , but `react-tether` has dependency on `react15` , so upgraded it. 
We have tested it , seems like its working fine.
Please merge to your master and release a new version.