### PR TITLE
[Feature] Support horizontalPostion: 'left'|'right'

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -4,12 +4,12 @@ import cx from 'classnames';
 
 export default class Dropdown extends Component {
   render() {
-    let { className, children } = this.props;
+    let { className, horizontalPosition, children } = this.props;
     return (
       <TetherComponent
         className={cx('PowerSelect__Tether', className && `${className}__Tether`)}
-        attachment="top left"
-        targetAttachment="bottom left"
+        attachment={`top ${horizontalPosition}`}
+        targetAttachment={`bottom ${horizontalPosition}`}
         constraints={[
           {
             to: 'window',

--- a/src/Select.js
+++ b/src/Select.js
@@ -345,6 +345,7 @@ export default class Select extends Component {
       optionComponent,
       placeholder,
       disabled,
+      horizontalPosition,
       selectedOptionComponent,
       selectedOptionLabelPath,
       triggerLHSComponent,
@@ -359,7 +360,7 @@ export default class Select extends Component {
     let selectApi = this.getPublicApi();
 
     return (
-      <Dropdown className={className}>
+      <Dropdown className={className} horizontalPosition={horizontalPosition}>
         <div
           ref={powerselect => {
             this.powerselect = powerselect;
@@ -438,6 +439,7 @@ Select.defaultProps = {
   selectedOptionComponent: null,
   beforeOptionsComponent: null,
   afterOptionsComponent: null,
+  horizontalPosition: 'left',
   matcher: matcher,
   onFocus: noop,
   onBlur: noop,


### PR DESCRIPTION
Support `horizontalPosition` to align the dropdown to `left/right` of the trigger. Default `horizontalPosition` is `left`. Fixes #60 

### horizontalPosition="left"

<img width="408" alt="Screen Shot 2019-10-12 at 2 02 53 PM" src="https://user-images.githubusercontent.com/2162441/66695913-69f22700-ecf9-11e9-9c75-4557e90d3184.png">

### horizontalPosition="right"

<img width="383" alt="Screen Shot 2019-10-12 at 2 03 15 PM" src="https://user-images.githubusercontent.com/2162441/66695915-6a8abd80-ecf9-11e9-83be-e72eea3cb07a.png">
