### PR TITLE
fix: scroll issue after scrolling and selecting elements

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -1,13 +1,9 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import cx from 'classnames';
 import Option from './Option';
 import { getOptionIndex, isOptGroup } from './utils';
 
-export default class Options extends Component {
-  componentWillReceiveProps({ options, highlightedOption }) {
-    this.scrollTo({ options, highlightedOption });
-  }
-
+export default class Options extends PureComponent {
   componentDidMount() {
     let { options, highlightedOption } = this.props;
     this.optionsListOffsetHeight = this.optionsList.offsetHeight;


### PR DESCRIPTION
## Description
- Situation arises when there is an already selected option, and user scrolls further away from the selected option in the options dropdown list, then when the user selects a different option, the selected option is not getting updated.
- This PR fixes it by removing `componentWillRecieveProps` as it getting called every time when user selects an option.
- Have also updated component to `PureComponent` for optimisation.
- Attaching video for reference

## Video reference
https://user-images.githubusercontent.com/93181930/236516316-4ba52fa0-2193-41a9-8eb6-6db29b31b1af.mov

